### PR TITLE
Use older syntax for creating the Uint8Array, for better compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,5 +51,5 @@ module.exports = function encodeUtf8 (input) {
     result.push(0xEF, 0xBF, 0xBD)
   }
 
-  return Uint8Array.from(result).buffer
+  return new Uint8Array(result).buffer
 }


### PR DESCRIPTION
For compatibility with JavaScript implementations that lacks the `Uint8Array.from()` function.