### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-/npm-debug.log

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-declare function encodeUtf8 (input: string): ArrayBuffer
-export = encodeUtf8
+/** @returns an ArrayBuffer with the `input` string represented as UTF8 encoded data */
+export default function encodeUtf8 (input: string): ArrayBuffer

--- a/index.js
+++ b/index.js
@@ -1,14 +1,12 @@
-'use strict'
+export default function encodeUtf8 (input) {
+  const result = []
+  const size = input.length
 
-module.exports = function encodeUtf8 (input) {
-  var result = []
-  var size = input.length
-
-  for (var index = 0; index < size; index++) {
-    var point = input.charCodeAt(index)
+  for (let index = 0; index < size; index++) {
+    let point = input.charCodeAt(index)
 
     if (point >= 0xD800 && point <= 0xDBFF && size > index + 1) {
-      var second = input.charCodeAt(index + 1)
+      const second = input.charCodeAt(index + 1)
 
       if (second >= 0xDC00 && second <= 0xDFFF) {
         // https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae

--- a/package.json
+++ b/package.json
@@ -3,11 +3,17 @@
   "version": "1.0.3",
   "license": "MIT",
   "repository": "LinusU/encode-utf8",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
-    "test": "standard && mocha"
+    "test": "standard && mocha && ts-readme-generator --check"
   },
   "devDependencies": {
-    "mocha": "^6.2.2",
-    "standard": "^14.3.1"
+    "mocha": "^9.0.2",
+    "standard": "^16.0.3",
+    "ts-readme-generator": "^0.5.1"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ npm install --save encode-utf8
 ## Usage
 
 ```js
-const encodeUtf8 = require('encode-utf8')
+import encodeUtf8 from 'encode-utf8'
 
 console.log(encodeUtf8('Hello, World!'))
 //=> ArrayBuffer { byteLength: 13 }
@@ -22,6 +22,7 @@ console.log(encodeUtf8('🐵 🙈 🙉 🙊'))
 
 ## API
 
-### `encodeUtf8(input: string): ArrayBuffer`
+### `encodeUtf8(input)`
 
-Returns an ArrayBuffer with the string represented as UTF8 encoded data.
+- `input` (`string`, required)
+- returns `ArrayBuffer` - an ArrayBuffer with the `input` string represented as UTF8 encoded data

--- a/test.js
+++ b/test.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 
-'use strict'
-
-const assert = require('assert')
-const encodeUtf8 = require('./')
+import assert from 'node:assert'
+import encodeUtf8 from './index.js'
 
 const testCases = [
   'ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ',


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`